### PR TITLE
Add 7 day default to setLogExpiry in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ logger = new logger({
 logger.setLogExpiry(10);
 // Deletes logs older than 10 days
 // Maximum value is 60 days
+// Default: 7 days
 ```
 
 ##### disableLogging():


### PR DESCRIPTION
I found this default value in `pruneOldLogs`. I'm assuming this is correct.